### PR TITLE
Wiki v3

### DIFF
--- a/docs/luckyblock/commands.md
+++ b/docs/luckyblock/commands.md
@@ -36,16 +36,17 @@ have 4 options to run command with:
   * Can add `-all` to destroy all LuckyBlocks (Not only corrupted). (Example: `lb destroy 0 0 0 -all`)
   * Can add `-silent` to not produce an output. (Example: `lb destroy 0 0 0 2 3 4 world -all -silent`)  
 ⚠ Permission required for command: `luckyblock.command.destroy`
-* `/ntdluckyblock generate <type> <factory> <min> <max>` - Regenerate config with new LuckyEntries. First argument -
-LuckyBlock type (For instance, `yellow`), second argument - factory version (Recommended `latest`), third and last
-argument - min and max entry drops.
+* `/ntdluckyblock generate <type> <min> <max> <entries-count>` - Regenerate LuckyBlock config with new entries.
+The first argument is the LuckyBlock type (For instance, `yellow`). `min` and `max` define the minimum and maximum
+number of drops generated inside each entry. The last argument defines how many entries will be generated.
 ⚠ Permission required for command: `luckyblock.command.generate`
 :::caution
-This command drops all setups inside LuckyBlock configuration. Prepare a backup
+This command removes all existing entries from the LuckyBlock configuration and replaces them with generated ones.
+Prepare a backup before using it.
 :::
 :::tip
-Example: `/ntdluckyblock generate yellow latest 100 150` will drop yellow configuration and insert
-from 100 to 150 entry drops
+Example: `/ntdluckyblock generate yellow 1 3 100` will generate and save `100` entries for the yellow LuckyBlock.
+Each entry will contain from `1` to `3` generated drops.
 :::
 * `/ntdluckyblock list` - Command to get all LuckyBlocks statuses (Enabled or disabled, entries amount,
 recipes amount *(Premium version contains a feature to all custom recipes for your LuckyBlocks)*)  

--- a/docs/luckyblock/setup/color.md
+++ b/docs/luckyblock/setup/color.md
@@ -234,13 +234,13 @@ Send a message to player
 - Additional Information: You can use placeholders in string-based drops, read more at the bottom on page
 ### SchematicDrop (`SCHEMATIC`)
 - Arguments map: `[file] [type] <air>`
-- Description example: `"SCHEMATIC : bedrock_problem : BLOCK_RELATIVE"`, `"SCHEMATIC : big_house : PLAYER_RELATIVE : true"`
+- Description example: `"SCHEMATIC : BedrockProblem : BLOCK_RELATIVE"`, `"SCHEMATIC : BlossomTree : PLAYER_RELATIVE : true"`
 - Additional Information: Schematic have two types `BLOCK_RELATIVE` and `PLAYER_RELATIVE`. This is responsible for where the schematic will be inserted.
 - The last argument represents if schematic air will be pasted (When `true` it is same as WE command `//paste -a`)
 
 :::tip
-The name (Like `bedrock_problem`, `big_house`) is a name of schematic without format type in directory
-`./plugins/ntdLuckyBlock/schematics/`. For instance, `bedrock_problem.schem`, `big_house.schematic`
+The name (Like `BedrockProblem`, `BlossomTree`) is a name of schematic without format type in directory
+`./plugins/ntdLuckyBlock/schematics/`. For instance, `BedrockProblem.schematic`, `BlossomTree.schem`
 :::
 
 #### Available schematics
@@ -273,15 +273,15 @@ You can use these schematics in `SCHEMATIC` drops:
 Use the value from **Schematic name** as the first argument:
 
 ```yml
-"SCHEMATIC : bedrock_problem : BLOCK"
-"SCHEMATIC : big_house : PLAYER : true"
+"SCHEMATIC : BedrockProblem : BLOCK"
+"SCHEMATIC : BlossomTree : PLAYER_RELATIVE : true"
 ```
 
 :::tip
 If your schematic file is named `arena.schem`, use only `arena` in the drop format:
 
 ```yml
-"SCHEMATIC : arena : BLOCK"
+"SCHEMATIC : arena : BLOCK_RELATIVE"
 ```
 :::
 

--- a/docs/luckyblock/setup/color.md
+++ b/docs/luckyblock/setup/color.md
@@ -70,57 +70,83 @@ I can make. Now premium in-game editor do not support schematics :( and you coul
 but nothing else. **Please use in-game editor.**
 :::
 
-- **Legacy (free version) style:**  
-You can add as many drops as you want.  
-All LuckyDrops split with unique names.  
-If you want to add new LuckyDrop you must add a new field `drop.number` and describe LuckyDrop using string list. Example:
-  ```$xslt
-  drop:
-    '0':
-    - description
-    - description...
-    '1':
-    - description
-    ...
-  ```
-:::tip
-  - You can find available descriptions at LuckyDrop types section. But before reading it you must familiarize with 
- my arguments designations.  
-  - I will use `[]` for required arguments and `<>` for not required arguments. I will use `<<>>` for unlimited/a
- large number of not required arguments.  
-  - LuckyDrop format will represent `TYPE : [argument] : <argument> : <<arguments>>` All arguments will be split
- with ` `**`:`**` ` (`:` with two spaces each side)
-:::
+You can add as many entries as you want. Each entry can contain one or more drops.
 
-- **JSON (Premium version) style**  
-:::warning
-If you are from free version, skip JSON style, otherwise..
-Please stop.. Use in-game editor.... If you are SO stubborn, you can use `/ntdluckyblock iteminfo`
-(Read more at [commands page](./../commands)) to get JSON format for item holding in hand
+```yml
+entries-mode: "ALL"
+entries:
+  '0':
+    chance: "AUTO"
+    mode: "ALL"
+    permission: "NONE"
+    drops:
+      - "MESSAGE : Hello %player%!"
+      - "ITEM : DIAMOND : 1 : 0"
+  '1':
+    chance: 10
+    mode: "1-2"
+    permission: "luckyblock.entry.example"
+    drops:
+      '0':
+        chance: "AUTO"
+        permission: "NONE"
+        node: "ENTITY : ZOMBIE : 3"
+      '1':
+        chance: 5
+        permission: "luckyblock.drop.diamond"
+        node: "ITEM : DIAMOND : 3 : 0"
+```
+
+### Entries mode
+
+`entries-mode` controls how many entries will be rolled when LuckyBlock is broken.
+
+- `"ALL"` - execute all available entries
+- `number` - execute exact amount of entries, for example `1` or `3`
+- `number-number` - execute random amount in range, for example `1-3`
+
+Default value is `1`.
+
+### Entry options
+
+- `chance` - entry chance. Values: `"AUTO"`, `LEVEL`, or weight number. Optional, default is `"AUTO"`
+- `mode` - how many drops inside this entry will be rolled. Values: `"ALL"`, `number`, or `number-number`. Optional, default is `"ALL"`
+- `permission` - permission required for this entry. Use `"NONE"` to disable permission check. Optional, default is `"NONE"`
+- `drops` - entry drops. Can be list-like or id-like
+
+### List-like drops
+
+Use list-like drops when all drops should have the same chance and no per-drop permissions.
+
+```yml
+drops:
+  - "MESSAGE : Hello %player%!"
+  - "ITEM : DIAMOND : 1 : 0"
+  - "SPECIAL : PIG"
+```
+
+### Id-like drops
+
+Use id-like drops when each drop needs its own chance or permission.
+
+```yml
+drops:
+  '0':
+    chance: "AUTO"
+    permission: "NONE"
+    node: "MESSAGE : Hello %player%!"
+  '1':
+    chance: 5
+    permission: "luckyblock.drop.diamond"
+    node: "ITEM : DIAMOND : 3 : 0"
+```
+
+:::tip
+- You can find available drop descriptions at LuckyDrop types section.
+- I will use `[]` for required arguments and `<>` for optional arguments.
+- I will use `<<>>` for unlimited or large number of optional arguments.
+- LuckyDrop format is `TYPE : [argument] : <argument> : <<arguments>>`. All arguments are split with ` `**`:`**` ` (`:` with two spaces each side).
 :::
-You can add LuckyDrops using legacy format and convert to JSON style using command `/ntdluckyblock convert`  
-JSON format style example:
-  ```$xslt
-  drop:
-    '0':
-      chance: CHANCE
-      items:
-        '0':
-          class: 'Clazz'
-          json: '{Json class instance}'
-        '1':
-          class: 'Clazz'
-          json: '{Json class instance}'
-        ...
-    '1':
-      chance: CHANCE
-      items:
-        '0':
-          class: 'Clazz'
-          json: '{Json class instance}'
-        ...
-    ...
-  ```
 
 ## LuckyDrop types
 
@@ -190,6 +216,49 @@ Send a message to player
 :::tip
 The name (Like `bedrock_problem`, `big_house`) is a name of schematic without format type in directory
 `./plugins/ntdLuckyBlock/schematics/`. For instance, `bedrock_problem.schem`, `big_house.schematic`
+:::
+
+#### Available schematics
+
+You can use these schematics in `SCHEMATIC` drops:
+
+| Schematic name | File name | Description |
+| --- | --- | --- |
+| `1_8n1` | `1_8n1.schematic` ||
+| `1_8n2` | `1_8n2.schematic` ||
+| `1_8n3` | `1_8n3.schematic` ||
+| `1_8n4` | `1_8n4.schematic` ||
+| `1_8n5` | `1_8n5.schematic` ||
+| `1_13n1` | `1_13n1.schem` ||
+| `1_13n2_b` | `1_13n2_b.schem` ||
+| `1_13n3` | `1_13n3.schem` ||
+| `1_13n4` | `1_13n4.schem` ||
+| `1_13n5` | `1_13n5.schem` ||
+| `1_13n6` | `1_13n6.schem` ||
+| `AncientPagoda` | `AncientPagoda.schem` | Ancient-style pagoda structure |
+| `ApocalypsysHouse` | `ApocalypsysHouse.schem` | Ruined apocalyptic house |
+| `bedrock_problem` | `bedrock_problem.schematic` | Bedrock trap structure |
+| `BlossomTree` | `BlossomTree.schem` | Decorative blossom tree |
+| `cage_lava` | `cage_lava.schem` | Lava cage trap |
+| `FlameShrine` | `FlameShrine.schematic` | Fire-themed shrine |
+| `LavaGuardian` | `LavaGuardian.schematic` | Lava guardian structure |
+| `small_temple` | `small_temple.schem` | Small temple structure |
+| `WatchTower` | `WatchTower.schematic` | Watchtower structure |
+
+Use the value from **Schematic name** as the first argument:
+
+```yml
+"SCHEMATIC : bedrock_problem : BLOCK"
+"SCHEMATIC : big_house : PLAYER : true"
+```
+
+:::tip
+If your schematic file is named `arena.schem`, use only `arena` in the drop format:
+
+```yml
+"SCHEMATIC : arena : BLOCK"
+```
+:::
 
 ### PigSpecial (`PIG`)
 - Special arguments map: `<amount>`
@@ -201,7 +270,7 @@ The name (Like `bedrock_problem`, `big_house`) is a name of schematic without fo
 - Special arguments map: `<amount>`
 - Description example:  `"SPECIAL : LIGHTNING : 4"`, `"SPECIAL : LIGHTNING"`
 ### DiamondColumnSpecial (`DIAMOND_COLUMN`)
-- Special arguments map> `<<block material>>`
+- Special arguments map: `<<block material>>`
 - Description example: `"SPECIAL : DIAMOND_COLUMN : RED_TERRACOTTA : YELLOW_TERRACOTTA : GREEN_TERRACOTTA : LIGHT_BLUE_TERRACOTTA : BLUE_TERRACOTTA : MAGENTA_TERRACOTTA"`
 ### ExperienceExplosionSpecial (`EXPERIENCE_EXPLOSION`)
 - Special arguments map: `<amount>`
@@ -215,6 +284,43 @@ The name (Like `bedrock_problem`, `big_house`) is a name of schematic without fo
 ### WitchAttackSpecial (`WITCH_ATTACK`)
 - Special arguments map: `<bats amount>`
 - Description example:  `"SPECIAL : WITCH_ATTACK : 4"`, `"SPECIAL : WITCH_ATTACK"`
+### JebSpecial (`JEB`)
+- Special arguments map: `<amount>`
+- Description example:  `"SPECIAL : JEB : 5"`, `"SPECIAL : JEB"`
+### CreepyMusicSpecial (`CREEPY_MUSIC`)
+- Special arguments map: `none`
+- Description example:  `"SPECIAL : CREEPY_MUSIC"`
+### ChickenRainSpecial (`CHICKEN_RAIN`)
+- Special arguments map: `<amount>`
+- Description example: `"SPECIAL : CHICKEN_RAIN : 20"`, `"SPECIAL : CHICKEN_RAIN"`
+### ParanoiaSpecial (`PARANOIA`)
+- Special arguments map: `none`
+- Description example: `"SPECIAL : PARANOIA"`
+### AnnoyingBabySpecial (`ANNOYING_BABY`)
+- Special arguments map: `<amount>`
+- Description example: `"SPECIAL : ANNOYING_BABY : 4"`,
+`"SPECIAL : ANNOYING_BABY"`
+### HotbarSwapSpecial (`HOTBAR_SWAP`)
+- Special arguments map: `none`
+- Description example: `"SPECIAL : HOTBAR_SWAP"`
+### BlackHoleSpecial (`BLACK_HOLE`)
+- Special arguments map: `none`
+- Description example: `"SPECIAL : BLACK_HOLE"`
+### GhostModeSpecial (`GHOST_MODE`)
+- Special arguments map: `none`
+- Description example: `"SPECIAL : GHOST_MODE"`
+### MoonGravitySpecial (`MOON_GRAVITY`)
+- Special arguments map: `none`
+- Description example: `"SPECIAL : MOON_GRAVITY"`
+### RandomTeleportSpecial (`RANDOM_TELEPORT`)
+- Special arguments map: `none`
+- Description example: `"SPECIAL : RANDOM_TELEPORT"`
+### SlipperyFingersSpecial (`SLIPPERY_FINGERS`)
+- Special arguments map: `none`
+- Description example: `"SPECIAL : SLIPPERY_FINGERS"`
+### TimeLoopSpecial (`TIME_LOOP`)
+- Special arguments map: `none`
+- Description example: `"SPECIAL : TIME_LOOP"`
 
 ### Placeholders for commands and messages:
 #### COMMAND, OPPED, CONSOLE, MESSAGE drops placeholders:

--- a/docs/luckyblock/setup/color.md
+++ b/docs/luckyblock/setup/color.md
@@ -114,6 +114,30 @@ Default value is `1`.
 - `permission` - permission required for this entry. Use `"NONE"` to disable permission check. Optional, default is `"NONE"`
 - `drops` - entry drops. Can be list-like or id-like
 
+### Chance and levels
+
+`chance` is a weight, not a direct percent value. Real chance is calculated from all available weights in the same roll.
+
+You can use a number directly or use a level name. Levels are configured in `config.yml` and formally work as a reference to a weight value.
+
+Example:
+
+```yml
+A:
+  chance: 30
+B:
+  chance: level1
+
+levels:
+  level1: 20
+```
+
+In this example `B` has weight `20`, because `level1` points to `20`.
+
+```text
+B = 20 / (20 + 30) = 40%
+```
+
 ### List-like drops
 
 Use list-like drops when all drops should have the same chance and no per-drop permissions.
@@ -210,9 +234,10 @@ Send a message to player
 - Additional Information: You can use placeholders in string-based drops, read more at the bottom on page
 ### SchematicDrop (`SCHEMATIC`)
 - Arguments map: `[file] [type] <air>`
-- Description example: `"SCHEMATIC : bedrock_problem : BLOCK"`, `"SCHEMATIC : big_house : PLAYER : true"`
-- Additional Information: Schematic have two types `BLOCK` and `PLAYER`. This is responsible for where the schematic will be inserted.
+- Description example: `"SCHEMATIC : bedrock_problem : BLOCK_RELATIVE"`, `"SCHEMATIC : big_house : PLAYER_RELATIVE : true"`
+- Additional Information: Schematic have two types `BLOCK_RELATIVE` and `PLAYER_RELATIVE`. This is responsible for where the schematic will be inserted.
 - The last argument represents if schematic air will be pasted (When `true` it is same as WE command `//paste -a`)
+
 :::tip
 The name (Like `bedrock_problem`, `big_house`) is a name of schematic without format type in directory
 `./plugins/ntdLuckyBlock/schematics/`. For instance, `bedrock_problem.schem`, `big_house.schematic`
@@ -224,25 +249,25 @@ You can use these schematics in `SCHEMATIC` drops:
 
 | Schematic name | File name | Description |
 | --- | --- | --- |
-| `1_8n1` | `1_8n1.schematic` ||
-| `1_8n2` | `1_8n2.schematic` ||
-| `1_8n3` | `1_8n3.schematic` ||
-| `1_8n4` | `1_8n4.schematic` ||
-| `1_8n5` | `1_8n5.schematic` ||
-| `1_13n1` | `1_13n1.schem` ||
-| `1_13n2_b` | `1_13n2_b.schem` ||
-| `1_13n3` | `1_13n3.schem` ||
-| `1_13n4` | `1_13n4.schem` ||
-| `1_13n5` | `1_13n5.schem` ||
-| `1_13n6` | `1_13n6.schem` ||
+| `JungleGazebo` | `JungleGazebo.schematic` | Jungle-themed gazebo |
+| `HellishChunk` | `HellishChunk.schematic` | Nether-style chunk structure |
+| `WoolFloor` | `WoolFloor.schematic` | Wool floor platform |
+| `DiamondTrap` | `DiamondTrap.schematic` | Diamond trap structure |
+| `DesertBoom` | `DesertBoom.schematic` | Desert explosion trap |
+| `TerracotaPlatform` | `TerracotaPlatform.schem` | Terracotta platform |
+| `OldCache` | `OldCache.schem` | Old hidden cache |
+| `SmallRetreat` | `SmallRetreat.schem` | Small retreat structure |
+| `PrismarineGazebo` | `PrismarineGazebo.schem` | Prismarine gazebo |
+| `EndArch` | `EndArch.schem` | End-themed arch |
+| `LavaDive` | `LavaDive.schem` | Lava dive trap |
 | `AncientPagoda` | `AncientPagoda.schem` | Ancient-style pagoda structure |
 | `ApocalypsysHouse` | `ApocalypsysHouse.schem` | Ruined apocalyptic house |
-| `bedrock_problem` | `bedrock_problem.schematic` | Bedrock trap structure |
+| `BedrockProblem` | `BedrockProblem.schematic` | Bedrock trap structure |
 | `BlossomTree` | `BlossomTree.schem` | Decorative blossom tree |
-| `cage_lava` | `cage_lava.schem` | Lava cage trap |
+| `CageLava` | `CageLava.schem` | Lava cage trap |
 | `FlameShrine` | `FlameShrine.schematic` | Fire-themed shrine |
 | `LavaGuardian` | `LavaGuardian.schematic` | Lava guardian structure |
-| `small_temple` | `small_temple.schem` | Small temple structure |
+| `SmallTemple` | `SmallTemple.schem` | Small temple structure |
 | `WatchTower` | `WatchTower.schematic` | Watchtower structure |
 
 Use the value from **Schematic name** as the first argument:

--- a/docs/luckyblock/setup/setupv2.md
+++ b/docs/luckyblock/setup/setupv2.md
@@ -1,0 +1,257 @@
+# LuckyBlock setup v2
+
+:::info Looking for the v3 setup guide?
+LuckyBlock v3 uses a newer configuration format.
+
+<a className="button button--primary" href="./setupv3">Open LuckyBlock setup v3</a>
+:::
+
+## Custom texture
+
+You can set custom texture for LuckyBlocks. By default, LuckyBlocks have build-in textures that can be found there  
+Texture format is unique id from skull url (Example: `8534b17d2d3b5a64c57f5f080dd777945761d9f71d82e8f599f242976e4d0c05`).  
+You can find it at the bottom of the heads page at [minecraft-heads.com](https://minecraft-heads.com)
+
+:::caution
+Incorrect texture will break LuckyBlock texture to steve  
+Sometimes minecraft client lags, please check texture from more than one pc if you suppose that custom texture  
+is not working. It should work!
+:::
+:::warning
+GeySer works bad with textures. We are not supporting GeySer. Texture may be a steve even with default setup
+:::
+
+Moreover, with premium version you can change item for LuckyBlock inside glass! (Config option `custom-head`)  
+You should pass json format item to it (You can get this format using command `/lb ii -tag -write`,
+[commands info](./../commands))
+Example:
+```yml
+custom-head:
+  enabled: true
+  item: '{"type":"GOLD_BLOCK","amount":1,"tag":""}'
+```
+![gold block](https://imgur.com/IniIpGs.png)
+
+You can create custom texture using resource pack.
+It could be with animation: [video mirror](https://i.imgur.com/CVRcwu6.mp4)
+<video src="https://i.imgur.com/CVRcwu6.mp4" autoplay muted controls loop></video>
+
+## Custom name and lore
+
+- You can set custom name (Item name) for LuckyBlocks. By default, it is `&<color_code><COLOR_NAME> LuckyBlock`.   
+Enter new name to `name` field like `name: "&4My cool LuckyBlock name"`. You can use same names for all LuckyBlocks.
+You can use colors with `&` symbol (Or hex using `&#rrggbb`)
+
+- You can also change custom system name (Will be used as a color for give commands and more).  
+Enter new name to `custom_name` field like `custom_name: "YELLOW"`
+:::tip
+Do not use colors for system name
+:::
+
+- You can change lore. Enter new lore to `lore` field:
+  ```
+  lore:
+  - "&7Oh boy, place me :D"
+  - "&7I am a LuckyBlock &6^_^"
+  ```
+
+## Shop & options
+
+You can sell LuckyBlocks using command `/ntdluckyblock gui get`. Setup:  
+- You can toggle LuckyBlock from being sold by setting `shop: false`.  
+- You can toggle LuckyBlock's cost by setting `price: <amount>` (Example: `price: 250`)  
+- You can toggle LuckyBlock's economy by setting `eco: false`. LuckyBlock will be available for free in the shop   
+
+:::info
+If shop is not working check permissions `luckyblock.gui.get` or `luckyblock.gui.get.<color>` based on your config setup
+:::
+
+## Drop formats
+
+:::caution
+If you came here and owning premium version, close this page and use `/ntdluckyblock gui edit`!  
+This system is not a joke, you SHOULD use in-game editor only for setup in premium version  
+Yes, you can still add drops using legacy style and convert in after, but it is kinda stupid. Only exception
+I can make. Now premium in-game editor do not support schematics :( and you could add it using legacy format only,
+but nothing else. **Please use in-game editor.**
+:::
+
+- **Legacy (free version) style:**  
+You can add as many drops as you want.  
+All LuckyDrops split with unique names.  
+If you want to add new LuckyDrop you must add a new field `drop.number` and describe LuckyDrop using string list. Example:
+  ```$xslt
+  drop:
+    '0':
+    - description
+    - description...
+    '1':
+    - description
+    ...
+  ```
+:::tip
+  - You can find available descriptions at LuckyDrop types section. But before reading it you must familiarize with 
+ my arguments designations.  
+  - I will use `[]` for required arguments and `<>` for not required arguments. I will use `<<>>` for unlimited/a
+ large number of not required arguments.  
+  - LuckyDrop format will represent `TYPE : [argument] : <argument> : <<arguments>>` All arguments will be split
+ with ` `**`:`**` ` (`:` with two spaces each side)
+:::
+
+- **JSON (Premium version) style**  
+:::warning
+If you are from free version, skip JSON style, otherwise..
+Please stop.. Use in-game editor.... If you are SO stubborn, you can use `/ntdluckyblock iteminfo`
+(Read more at [commands page](./../commands)) to get JSON format for item holding in hand
+:::
+You can add LuckyDrops using legacy format and convert to JSON style using command `/ntdluckyblock convert`  
+JSON format style example:
+  ```$xslt
+  drop:
+    '0':
+      chance: CHANCE
+      items:
+        '0':
+          class: 'Clazz'
+          json: '{Json class instance}'
+        '1':
+          class: 'Clazz'
+          json: '{Json class instance}'
+        ...
+    '1':
+      chance: CHANCE
+      items:
+        '0':
+          class: 'Clazz'
+          json: '{Json class instance}'
+        ...
+    ...
+  ```
+
+## LuckyDrop types
+
+:::caution
+Read careful all styles. Legacy format is made for free version and limited in functionalities.  
+You cannot add NBT items and there may be some small issues, but you can anyway use free version,
+it was developed with love (Originally I have not even planned premium version and legacy format was main)
+:::
+
+Topics below presents key type and arguments map, read style again:
+:::tip
+- You can find available descriptions at LuckyDrop types section. But before reading it you must familiarize with
+  my arguments designations.
+- I will use `[]` for required arguments and `<>` for not required arguments. I will use `<<>>` for unlimited/a
+  large number of not required arguments.
+- LuckyDrop format will represent `TYPE : [argument] : <argument> : <<arguments>>` All arguments will be split
+  with ` `**`:`**` ` (`:` with two spaces each side)
+:::
+
+### CommandDrop (`COMMAND`)
+Dispatch a command by a player
+- Arguments map: `[command]`
+- Description example: `"COMMAND : say Hello %player%!"`
+- Additional Information: You can use placeholders in string-based drops, read more at the bottom on page
+### ConsoleDrop (`OPPED`)
+Dispatch a command by an opped player
+- Arguments map: `[command]`
+- Description example: `"OPPED : gamemode creative"`
+- Additional Information: You can use placeholders in string-based drops, read more at the bottom on page
+### ConsoleDrop (`CONSOLE`)
+Dispatch a command by console
+- Arguments map: `[command]`
+- Description example: `"CONSOLE : give %player% diamond"`
+- Additional Information: You can use placeholders in string-based drops, read more at the bottom on page
+### EntityDrop (`ENTITY`)
+Summon an entity
+- Arguments map: `[entity type] <amount>`
+- Description example: `"ENTITY : GHAST"`, `"ENTITY : GHAST : 4"`
+- Additional Information: You can find entity types [here](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html)
+### ItemDrop (`ITEM`)
+Drop an item
+- Arguments map: `[material] [amount] [data] <name> <<[enchantment] [level]>>`
+- Description example: `"ITEM : IRON_SWORD : 1 : 0"`, `"ITEM : IRON_SWORD : 1 : 0 : Iron sword : DAMAGE_ALL : 2"`
+- Additional Information: For 1.8 - 1.12 servers data will change multiblock types 
+(Wool color (Example `WOOL : 1 : 14` - one red wool), stone type) and also tools corruption.
+For 1.13+ servers you must provide data "0" for all blocks and corruption amount for tools. 
+### CustomItemDrop (`CUSTOM_ITEM`)
+Drop a custom item from LuckyBlock plugin (Or any other plugin hooked into mine)
+- Arguments map: `[item id] <amount>`
+- Description example: `CUSTOM_ITEM : magic_wool : 5`
+- Additional Information: You can get custom items list using `/ntdluckyblock customitemslist`
+### LuckyItemDrop (`LUCKY_BLOCK_ITEM`)
+Drop a LuckyBlock as an item
+- Arguments map: `[type] <amount>`
+- Description example: `"LUCKY_BLOCK_ITEM : BLUE : 2"`, `"LUCKY_BLOCK_ITEM : RANDOM"`, `"LUCKY_BLOCK_ITEM : BLACK"`
+- Additional Information: Check if your LuckyBlock is enabled (How we can drop a red LuckyBlock if it was disabled?)
+### MessageDrop (`MESSAGE`)
+Send a message to player
+- Arguments map: `[message]`
+- Description example: `"MESSAGE : Hello %player%!"`
+- Additional Information: You can use placeholders in string-based drops, read more at the bottom on page
+### SchematicDrop (`SCHEMATIC`)
+- Arguments map: `[file] [type] <air>`
+- Description example: `"SCHEMATIC : bedrock_problem : BLOCK"`, `"SCHEMATIC : big_house : PLAYER : true"`
+- Additional Information: Schematic have two types `BLOCK` and `PLAYER`. This is responsible for where the schematic will be inserted.
+- The last argument represents if schematic air will be pasted (When `true` it is same as WE command `//paste -a`)
+:::tip
+The name (Like `bedrock_problem`, `big_house`) is a name of schematic without format type in directory
+`./plugins/ntdLuckyBlock/schematics/`. For instance, `bedrock_problem.schem`, `big_house.schematic`
+
+### PigSpecial (`PIG`)
+- Special arguments map: `<amount>`
+- Description example:  `"SPECIAL : PIG"`, `SPECIAL : PIG : 4`
+### WaterBucketSpecial (`WATER_BUCKET`)
+- Special arguments map: `<height>`
+- Description example:  `"SPECIAL : WATER_BUCKET : 64"`, `"SPECIAL : WATER_BUCKET"`
+### LightningSpecial (`LIGHTNING`)
+- Special arguments map: `<amount>`
+- Description example:  `"SPECIAL : LIGHTNING : 4"`, `"SPECIAL : LIGHTNING"`
+### DiamondColumnSpecial (`DIAMOND_COLUMN`)
+- Special arguments map> `<<block material>>`
+- Description example: `"SPECIAL : DIAMOND_COLUMN : RED_TERRACOTTA : YELLOW_TERRACOTTA : GREEN_TERRACOTTA : LIGHT_BLUE_TERRACOTTA : BLUE_TERRACOTTA : MAGENTA_TERRACOTTA"`
+### ExperienceExplosionSpecial (`EXPERIENCE_EXPLOSION`)
+- Special arguments map: `<amount>`
+- Description example:  `"SPECIAL : EXPERIENCE_EXPLOSION : 4"`, `"SPECIAL : EXPERIENCE_EXPLOSION"`
+### TntExplosionSpecial (`TNT_EXPLOSION`)
+- Special arguments map: `<amount>`
+- Description example:  `"SPECIAL : TNT_EXPLOSION : 4"`, `"SPECIAL : TNT_EXPLOSION"`
+### TntColumnSpecial (`TNT_COLUMN`)
+- Special arguments map: `<amount>`
+- Description example:  `"SPECIAL : TNT_COLUMN : 4"`, `"SPECIAL : TNT_COLUMN"`
+### WitchAttackSpecial (`WITCH_ATTACK`)
+- Special arguments map: `<bats amount>`
+- Description example:  `"SPECIAL : WITCH_ATTACK : 4"`, `"SPECIAL : WITCH_ATTACK"`
+
+### Placeholders for commands and messages:
+#### COMMAND, OPPED, CONSOLE, MESSAGE drops placeholders:
+* `%world%` - World string name (Example: `world_the_end`)
+* `%player%` - Player name (Example: `Danirod_Gaming`)  
+#### COMMAND, OPPED, CONSOLE drops placeholders:  
+Location format is `%<player/block>_<location/x/y/z>[_above_<value>][_move_(value,value,value)][_int]%`  
+Now we will talk a bit more, with examples:
+
+##### First argument `<block/player>` stands for LuckyBlock and Player that breaks LuckyBlock:
+* `%block_location%` - LuckyBlock location string (Example: `-121.5 63.5 99122.5`)
+* `%player_location%` - Player location string (Example: `-125.27 64.13 99123.86`)
+##### Last param `_int` defines that location would be rounded:
+* `%block_location_int%` - Location rounded (Example: `-121 63 99122`) **You possibly need this one ⚠**
+* `%player_location_int%` - Location string (Example: `-125 64 99123`) **You possibly need this one ⚠**
+##### Param `move_(value,value,value)` moves location to (value,value,value) vector:
+* `%player_location_move_(1,2,1)` - Location moved to offset of (x: 1, y: 2, z: 1), not rounded
+* `%player_location_move_(1,2,1)_int` - Location moved to offset of (x: 1, y: 2, z: 1), rounded
+* `%block_x_move_(1,0,0)_int%` - We take block location, move it 1 block for x and returns rounded x
+##### Param `above_<value>` is something like `move_(0,value,0)` param, moving only for Y:
+* `%<player/block>_location_above_<value>[_int]` - Location with offset of "value" blocks high  
+(Example: origin location is `0 0.5 2.65`, with `%<player/block>_location_above_10%` you will get `0 10.5 2.65`,
+with `%<player/block>_location_above_-1_int%` you will get `0 -1 2`)
+
+:::tip
+As for `move_(value,value,value)`, `above_value` supports negative numbers,
+so `%player_location_above_-1_int%` is a location 1 block below the player
+:::
+##### Deprecated, but still supported
+* ~~`%location%`~~ - *Deprecated*. (Same as `%player_location%`)
+
+##### Combining is your power:
+`CONSOLE : fill %player_x_move_(-1,0,0)_int% %block_y_int% %player_z_move_(0,0,-1)_int% %player_x_move_(1,0,0)_int% %block_y_int% %player_z_move_(0,0,1)_int% tnt`
+This simple console command fills 3x3 blocks with tnt at Player X and Z, but on LuckyBlocks Y

--- a/docs/luckyblock/setup/setupv3.md
+++ b/docs/luckyblock/setup/setupv3.md
@@ -1,4 +1,10 @@
-# LuckyBlock setup
+# LuckyBlock setup v3
+
+:::info Looking for the v2 setup guide?
+Use the legacy setup guide if your server is running LuckyBlock v2.
+
+<a className="button button--primary" href="./setupv2">Open LuckyBlock setup v2</a>
+:::
 
 ## Custom texture
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -33,7 +33,8 @@ const sidebars = {
           label: 'Setup',
           items: [
             'luckyblock/setup/config',
-            'luckyblock/setup/color',
+            'luckyblock/setup/setupv2',
+            'luckyblock/setup/setupv3',
           ],
         },
       ],


### PR DESCRIPTION
## Summary

  Updates the LuckyBlock wiki for v3 while
  preserving the legacy v2 setup
  documentation.

  ## Changes

  - Renamed the legacy `color.md` setup page
  to `setupv2.md`
  - Added a separate `setupv3.md`
  configuration guide
  - Added navigation buttons between the v2
  and v3 setup guides
  - Updated the Setup sidebar with both
  documentation versions
  - Reworked the v3 Drop formats section:
    - Documented `entries-mode` and entry
  options
    - Added list-like and id-like drop
  examples
    - Explained chance weights and configured
  levels
  - Added available schematic names and
  descriptions
  - Added documentation for new special drops
  and their arguments
  - Updated the `generate` command syntax and
  behavior

  ## Verification

  - Successfully built the documentation with
  `npm run build`
  `npm start`
  - Verified that both setup pages are
  available through the sidebar
  - Verified links between the v2 and v3 setup
  guides